### PR TITLE
make isClientConfigured a bit more ergonomic

### DIFF
--- a/.changeset/eighty-dryers-eat.md
+++ b/.changeset/eighty-dryers-eat.md
@@ -1,0 +1,7 @@
+---
+"fogbender-react": patch
+"fogbender-vue": patch
+---
+
+Update `FogbenderIsConfigured` to support new return type of `isClientConfigured`.
+Return type of `isClientConfigured` in versions 0.1 and 0.2 of `fogbender` package are not compatible.

--- a/.changeset/pink-birds-sort.md
+++ b/.changeset/pink-birds-sort.md
@@ -1,0 +1,8 @@
+---
+"fogbender": minor
+---
+
+BREAKING CHANGE: type of isClientConfigured has changed
+
+Snapshot callbacks no longer receive the snapshot as an argument
+but instead get the value itself.

--- a/packages/fogbender-react/src/FogbenderIsConfigured.tsx
+++ b/packages/fogbender-react/src/FogbenderIsConfigured.tsx
@@ -27,12 +27,7 @@ export function useFromSnapshot<T>(snapshotGen: () => Promise<Snapshot<T>>, init
     const unsub = [] as (() => void)[];
     const run = async () => {
       const snapshot = await snapshotGen();
-      setValue(snapshot.getValue());
-      unsub.push(
-        snapshot.subscribe(s => {
-          setValue(s.getValue());
-        })
-      );
+      unsub.push(snapshot.subscribe(setValue));
     };
     run();
     return () => {

--- a/packages/fogbender-vue/src/components/FogbenderIsConfigured.ts
+++ b/packages/fogbender-vue/src/components/FogbenderIsConfigured.ts
@@ -12,12 +12,9 @@ export default defineComponent({
       const fb = inject(fogbender);
       if (fb) {
         const snapshot = await fb.isClientConfigured();
-
-        isConfigured.value = snapshot.getValue();
-
         unsub.push(
-          snapshot.subscribe(s => {
-            isConfigured.value = s.getValue();
+          snapshot.subscribe(v => {
+            isConfigured.value = v;
           })
         );
       }

--- a/packages/fogbender/src/index.ts
+++ b/packages/fogbender/src/index.ts
@@ -2,7 +2,7 @@ import { checkToken } from "./checkToken";
 import { createEvents, renderIframe } from "./createIframe";
 import { createFloatingWidget } from "./floatingWidget";
 import { renderUnreadBadge } from "./renderUnreadBadge";
-import type { Env, Fogbender, Snapshot, Token } from "./types";
+import type { Env, Fogbender, Token } from "./types";
 export type {
   Env,
   Token,
@@ -73,8 +73,10 @@ export const createNewFogbender = (): Fogbender => {
     async isClientConfigured() {
       const snapshot = {
         getValue: () => state.events.configured,
-        subscribe: (cb: (s: Snapshot<boolean>) => void) => {
-          return state.events.on("configured", () => cb(snapshot));
+        subscribe: (cb: (value: boolean) => void) => {
+          const setState = () => cb(state.events.configured);
+          setState();
+          return state.events.on("configured", setState);
         },
       };
       return snapshot;

--- a/packages/fogbender/src/index.ts
+++ b/packages/fogbender/src/index.ts
@@ -74,9 +74,8 @@ export const createNewFogbender = (): Fogbender => {
       const snapshot = {
         getValue: () => state.events.configured,
         subscribe: (cb: (value: boolean) => void) => {
-          const setState = () => cb(state.events.configured);
-          setState();
-          return state.events.on("configured", setState);
+          cb(state.events.configured);
+          return state.events.on("configured", cb);
         },
       };
       return snapshot;

--- a/packages/fogbender/src/types.ts
+++ b/packages/fogbender/src/types.ts
@@ -45,9 +45,12 @@ export type Badge = {
   roomType: string;
 };
 
+/**
+ * Snapshot value changes over time and stores the last value. Subscription callback will be called at the start with the current value when subscribed.
+ */
 export type Snapshot<T> = {
   getValue: () => T;
-  subscribe: (cb: (s: Snapshot<T>) => void) => () => void;
+  subscribe: (cb: (v: T) => void) => () => void;
 };
 
 export interface Fogbender {


### PR DESCRIPTION
Make `isClientConfigured` a bit easier to use. See more details in e6f2aad3eddcc343f3c99a5aa0a983f5148bc29f