### PR TITLE
proto: add `slack-customer` as one of possible integration names

### DIFF
--- a/.changeset/serious-hairs-guess.md
+++ b/.changeset/serious-hairs-guess.md
@@ -1,0 +1,5 @@
+---
+"fogbender-proto": patch
+---
+
+proto: add slack-customer as one of possible integration names

--- a/packages/fogbender-proto/src/schema.ts
+++ b/packages/fogbender-proto/src/schema.ts
@@ -795,7 +795,7 @@ export const KnownIssueTrackerIntegrations = [
 ];
 export type KnownIssueTrackerIntegration = typeof KnownIssueTrackerIntegrations[number];
 
-export const KnownCommsIntegrations = ["slack", "msteams"];
+export const KnownCommsIntegrations = ["slack", "msteams", "slack-customer"];
 export type KnownCommsIntegration = typeof KnownCommsIntegrations[number];
 
 export type Tag = {


### PR DESCRIPTION
* sync with fogbender 35311b1ce21648fbed8ef57acc7ea65bfc330284