### PR TITLE
process.env support in qgp

### DIFF
--- a/.changeset/quiet-apricots-notice.md
+++ b/.changeset/quiet-apricots-notice.md
@@ -1,0 +1,5 @@
+---
+"qgp": patch
+---
+
+support process.env.REACT_APP env variables

--- a/packages/qgp/cli/add/run-add-interactive.ts
+++ b/packages/qgp/cli/add/run-add-interactive.ts
@@ -93,7 +93,7 @@ export async function runAddInteractive(app: AppCommand, id: string | undefined)
   const commit = await logUpdateAppResult(pkgManager, result);
   if (commit) {
     await result.commit(true);
-    const postInstall = result.integration.pkgJson.__qwik__?.postInstall;
+    const postInstall = result.integration.pkgJson.__qgp__?.postInstall;
     if (postInstall) {
       const spinner = startSpinner(`Running post install script: ${postInstall}`);
       await runInPkg(pkgManager, postInstall.split(" "), app.rootDir);
@@ -199,6 +199,6 @@ function logUpdateAppCommitResult(result: UpdateAppResult) {
   );
   console.log(``);
   logSuccessFooter(result.integration.docs);
-  const nextSteps = result.integration.pkgJson.__qwik__?.nextSteps;
+  const nextSteps = result.integration.pkgJson.__qgp__?.nextSteps;
   logNextStep(nextSteps);
 }

--- a/packages/qgp/cli/add/update-vite-config.ts
+++ b/packages/qgp/cli/add/update-vite-config.ts
@@ -18,7 +18,7 @@ export async function updateViteConfigs(
   rootDir: string
 ) {
   try {
-    const viteConfig = integration.pkgJson.__qwik__?.viteConfig;
+    const viteConfig = integration.pkgJson.__qgp__?.viteConfig;
     if (viteConfig) {
       const viteConfigPath = join(rootDir, "vite.config.ts");
       const destContent = await fs.promises.readFile(viteConfigPath, "utf-8");

--- a/packages/qgp/cli/types.ts
+++ b/packages/qgp/cli/types.ts
@@ -89,7 +89,7 @@ export interface IntegrationPackageJson {
     postInstall?: string;
     viteConfig?: ViteConfigUpdates;
   };
-  __qwik__?: {
+  __qgp__?: {
     displayName?: string;
     nextSteps?: NextSteps;
     docs?: string[];

--- a/packages/qgp/cli/utils/integrations.ts
+++ b/packages/qgp/cli/utils/integrations.ts
@@ -59,8 +59,8 @@ export async function loadIntegrations() {
               type: "feature",
               dir,
               pkgJson,
-              docs: pkgJson.__qwik__?.docs ?? [],
-              priority: pkgJson?.__qwik__?.priority ?? 0,
+              docs: pkgJson.__qgp__?.docs ?? [],
+              priority: pkgJson?.__qgp__?.priority ?? 0,
             };
             console.log(integration);
             loadingIntegrations.push(integration);

--- a/packages/qgp/cli/utils/log.ts
+++ b/packages/qgp/cli/utils/log.ts
@@ -17,9 +17,8 @@ export function logSuccessFooter(docs: string[]) {
     });
   }
   console.log(``);
-  console.log(`💬 ${color.cyan("Questions? Start the conversation at:")}`);
-  console.log(`   https://qwik.builder.io/chat`);
-  console.log(`   https://twitter.com/QwikDev`);
+  console.log(`💬 ${color.cyan("Questions?")}`);
+  console.log(`   https://twitter.com/JLarky`);
   console.log(``);
 }
 

--- a/packages/qgp/cli/utils/utils.ts
+++ b/packages/qgp/cli/utils/utils.ts
@@ -44,7 +44,7 @@ export function cleanPackageJson(srcPkg: IntegrationPackageJson) {
   Object.keys(cleanedPkg).forEach(prop => {
     delete (srcPkg as any)[prop];
   });
-  delete srcPkg.__qwik__;
+  delete srcPkg.__qgp__;
 
   const sortedKeys = Object.keys(srcPkg).sort();
   for (const key of sortedKeys) {

--- a/packages/qgp/src/index.ts
+++ b/packages/qgp/src/index.ts
@@ -10,6 +10,7 @@ export function testFunction(name: string) {
 }
 
 export type QgpConfig<T extends UserConfig> = {
+  skipReactAppEnv?: boolean;
   skipEnvCompatible?: boolean;
   skipTsconfigPaths?: boolean;
   vite: T;
@@ -24,6 +25,9 @@ export function defineCommon<T extends UserConfig>(config: QgpConfig<T>): T {
     plugins.push(tsconfigPaths());
   }
   const userConfig: UserConfig = { plugins };
+  if (!config.skipReactAppEnv) {
+    userConfig.envPrefix = "REACT_APP_";
+  }
   const conf = mergeConfig(config.vite, userConfig);
   return conf as T;
 }

--- a/packages/qgp/templates/astro/qgp.config.mjs
+++ b/packages/qgp/templates/astro/qgp.config.mjs
@@ -12,7 +12,4 @@ export const common = defineCommon({
 
 export default defineVite(common, {
   plugins: [react()],
-  define: {
-    "global": "window",
-  },
 });

--- a/packages/qgp/templates/qgp-ts/index.html
+++ b/packages/qgp/templates/qgp-ts/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./src/qgp.tsx"></script>
+    <script type="module" src="./src/qgp/vite.tsx"></script>
   </body>
 </html>

--- a/packages/qgp/templates/qgp-ts/package.json
+++ b/packages/qgp/templates/qgp-ts/package.json
@@ -12,5 +12,16 @@
     "@vitejs/plugin-react": "*",
     "typescript": "*",
     "vite-plugin-checker": "*"
+  },
+  "__qgp__": {
+    "displayName": "qgp-ts (adds start-qgp script that uses vite)",
+    "nextSteps": {
+      "title": "What's next?",
+      "lines": [
+        "- make sure to rename your existing .ts files to .tsx",
+        "- try running `npm run start-qgp`"
+      ]
+    },
+    "priority": 11
   }
 }

--- a/packages/qgp/templates/qgp-ts/qgp.config.mjs
+++ b/packages/qgp/templates/qgp-ts/qgp.config.mjs
@@ -19,7 +19,4 @@ export default defineVite(common, {
       overlay: { initialIsOpen: false },
     }),
   ],
-  define: {
-    "global": "window",
-  },
 });

--- a/packages/qgp/templates/qgp-ts/src/qgp.tsx
+++ b/packages/qgp/templates/qgp-ts/src/qgp.tsx
@@ -1,6 +1,0 @@
-window.process = window.process || { env: { NODE_ENV: "production" } };
-window.process.env = import.meta.env || {};
-import ReactDOM from "react-dom";
-import { App } from "./components/ReactSPA";
-
-ReactDOM.render(<App />, document.getElementById("root")!);

--- a/packages/qgp/templates/qgp-ts/src/qgp/env.ts
+++ b/packages/qgp/templates/qgp-ts/src/qgp/env.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+window.global = window.global || window;
+window.process = window.process || {};
+process.env = process.env || {};
+process.env = Object.assign(process.env, import.meta.env);

--- a/packages/qgp/templates/qgp-ts/src/qgp/react.tsx
+++ b/packages/qgp/templates/qgp-ts/src/qgp/react.tsx
@@ -1,5 +1,5 @@
+import "./env";
 import ReactSPA from "../App";
-import "../styles/tailwind.css";
 
 export const App = () => {
   return <ReactSPA />;

--- a/packages/qgp/templates/qgp-ts/src/qgp/vite.tsx
+++ b/packages/qgp/templates/qgp-ts/src/qgp/vite.tsx
@@ -1,0 +1,13 @@
+// please move the content of your src/index.ts here
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "../index.css";
+
+import { App } from "./react";
+
+const root = ReactDOM.createRoot(document.getElementById("root")!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/qgp/templates/qgp/index.html
+++ b/packages/qgp/templates/qgp/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./src/qgp.jsx"></script>
+    <script type="module" src="./src/qgp/vite.jsx"></script>
   </body>
 </html>

--- a/packages/qgp/templates/qgp/package.json
+++ b/packages/qgp/templates/qgp/package.json
@@ -10,5 +10,16 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^3.0.0"
+  },
+  "__qgp__": {
+    "displayName": "qgp (adds start-qgp script that uses vite, javasript only)",
+    "nextSteps": {
+      "title": "What's next?",
+      "lines": [
+        "- make sure to rename your existing .js files to .jsx",
+        "- try running `npm run start-qgp`"
+      ]
+    },
+    "priority": 10
   }
 }

--- a/packages/qgp/templates/qgp/qgp.config.mjs
+++ b/packages/qgp/templates/qgp/qgp.config.mjs
@@ -12,7 +12,4 @@ export const common = defineCommon({
 
 export default defineVite(common, {
   plugins: [react()],
-  define: {
-    "global": "window",
-  },
 });

--- a/packages/qgp/templates/qgp/src/qgp.jsx
+++ b/packages/qgp/templates/qgp/src/qgp.jsx
@@ -1,5 +1,0 @@
-import ReactDOM from "react-dom";
-
-import { App } from "./components/ReactSPA";
-
-ReactDOM.render(<App />, document.getElementById("root"));

--- a/packages/qgp/templates/qgp/src/qgp/env.js
+++ b/packages/qgp/templates/qgp/src/qgp/env.js
@@ -1,0 +1,4 @@
+window.global = window.global || window;
+window.process = window.process || {};
+process.env = process.env || {};
+process.env = Object.assign(process.env, import.meta.env);

--- a/packages/qgp/templates/qgp/src/qgp/react.jsx
+++ b/packages/qgp/templates/qgp/src/qgp/react.jsx
@@ -1,3 +1,4 @@
+import "./env";
 import ReactSPA from "../App";
 
 export const App = () => {

--- a/packages/qgp/templates/qgp/src/qgp/vite.jsx
+++ b/packages/qgp/templates/qgp/src/qgp/vite.jsx
@@ -1,0 +1,13 @@
+// please move the content of your src/index.js here
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "../index.css";
+
+import { App } from "./react";
+
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
improve qgp templates with support for REACT_APP env variables and proper compatibility of `process.env`

- improve instructions
- `skipReactAppEnv` to disable `REACT_APP` behavior