### PR TITLE
Fix iFrame height calculation

### DIFF
--- a/.changeset/fast-buckets-float.md
+++ b/.changeset/fast-buckets-float.md
@@ -1,0 +1,5 @@
+---
+"fogbender": patch
+---
+
+Fix iFrame height calculation so things work nicely when there is a footer below the iFrame.

--- a/packages/fogbender/src/createIframe.ts
+++ b/packages/fogbender/src/createIframe.ts
@@ -137,9 +137,31 @@ export function renderIframe(
     if (!rootEl || disableFit) {
       return;
     }
+    const totalFooterHeight = (el, acc) => {
+      const cs = getComputedStyle(el);
+      const x =
+        parseInt(cs.paddingBottom) + parseInt(cs.marginBottom) + parseInt(cs.borderBottomWidth);
+
+      if (el.parentElement) {
+        return totalFooterHeight(el.parentElement, acc + x);
+      }
+
+      return acc;
+    };
+
+    let heightBelow = 0;
+
+    try {
+      const iFrameTopBorderWidth = parseInt(getComputedStyle(iFrame).borderTopWidth);
+      heightBelow = Math.max(totalFooterHeight(iFrame, 0) + iFrameTopBorderWidth, 0);
+    } catch (e) {}
+
     const height = headless
       ? 0
-      : Math.min(window.innerHeight, window.innerHeight - rootEl.getBoundingClientRect().top);
+      : Math.min(
+          window.innerHeight,
+          window.innerHeight - heightBelow - rootEl.getBoundingClientRect().top
+        );
     iFrame.style.height = height + "px";
   }
 

--- a/packages/fogbender/src/createIframe.ts
+++ b/packages/fogbender/src/createIframe.ts
@@ -137,7 +137,7 @@ export function renderIframe(
     if (!rootEl || disableFit) {
       return;
     }
-    const totalFooterHeight = (el, acc) => {
+    const totalFooterHeight = (el: Element, acc: number): number => {
       const cs = getComputedStyle(el);
       const x =
         parseInt(cs.paddingBottom) + parseInt(cs.marginBottom) + parseInt(cs.borderBottomWidth);


### PR DESCRIPTION
When calculating height of iFrame on resize, take into account the iFrame's topBorder width and marginBottom/paddingBottom/bottomBorder of all parents